### PR TITLE
Proper PWA support (icons, manifest, service worker)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,26 @@
+{
+  "name": "Fifteen Tile Puzzle",
+  "short_name": "Fifteen",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": [
+    {
+      "src": "icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    },
+    {
+      "src": "icon-180.png",
+      "sizes": "180x180",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,30 @@
+const CACHE_NAME = 'tile-puzzle-v2';
+const urlsToCache = [
+  '/',
+  '/index.html',
+  '/puzzle.css',
+  '/puzzle.js',
+  '/icon-192.png',
+  '/icon-512.png',
+  '/icon-180.png'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(urlsToCache))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(
+      keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k))
+    ))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});


### PR DESCRIPTION
Adds full Progressive Web App support based on current main branch:

- manifest.json with 192, 512, and 180 icons
- service worker with cache + versioning + icon caching
- ready for Android install (Chrome)
- compatible with iOS (via apple-touch-icon if added to HTML)

Note: index.html should include:
<link rel="manifest" href="manifest.json">
<meta name="theme-color" content="#ffffff">
<link rel="apple-touch-icon" href="icon-180.png">

and service worker registration script.

Kept changes additive to avoid overwriting recent work.